### PR TITLE
Fix four audited correctness bugs (NodeKey-rotation DoS, PKCE, verify CT, server_url)

### DIFF
--- a/hscontrol/handlers.go
+++ b/hscontrol/handlers.go
@@ -180,13 +180,18 @@ func (h *Headscale) VerifyHandler(
 
 	req.Body = http.MaxBytesReader(writer, req.Body, verifyBodyLimit)
 
+	// Set the Content-Type before any body byte is written. The first
+	// Write in handleVerifyRequest triggers an implicit WriteHeader that
+	// snapshots the header map, so setting it afterwards is a no-op. The
+	// error path resets the Content-Type via http.Error, so error
+	// responses remain text/plain.
+	writer.Header().Set("Content-Type", "application/json")
+
 	err := h.handleVerifyRequest(req, writer)
 	if err != nil {
 		httpError(writer, err)
 		return
 	}
-
-	writer.Header().Set("Content-Type", "application/json")
 }
 
 // KeyHandler provides the Headscale pub key
@@ -304,14 +309,16 @@ func (a *AuthProviderWeb) RegisterURL(authID types.AuthID) string {
 	return fmt.Sprintf(
 		"%s/register/%s",
 		strings.TrimSuffix(a.serverURL, "/"),
-		authID.String())
+		authID.String(),
+	)
 }
 
 func (a *AuthProviderWeb) AuthURL(authID types.AuthID) string {
 	return fmt.Sprintf(
 		"%s/auth/%s",
 		strings.TrimSuffix(a.serverURL, "/"),
-		authID.String())
+		authID.String(),
+	)
 }
 
 func (a *AuthProviderWeb) AuthHandler(

--- a/hscontrol/handlers_test.go
+++ b/hscontrol/handlers_test.go
@@ -3,13 +3,19 @@ package hscontrol
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"strings"
 	"testing"
 
+	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/key"
 )
 
 var errTestUnexpected = errors.New("unexpected failure")
@@ -45,6 +51,69 @@ func TestHandleVerifyRequest_OversizedBodyRejected(t *testing.T) {
 
 	assert.Equal(t, http.StatusRequestEntityTooLarge, httpErr.Code,
 		"oversized body must surface 413")
+}
+
+// TestVerifyHandler_SuccessSetsJSONContentType verifies that a successful
+// POST to /verify advertises Content-Type: application/json. The header
+// must be set before the JSON body is written, otherwise the implicit
+// WriteHeader on first Write locks in a sniffed content type and the
+// later Header().Set becomes a no-op.
+func TestVerifyHandler_SuccessSetsJSONContentType(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	prefixV4 := netip.MustParsePrefix("100.64.0.0/10")
+	prefixV6 := netip.MustParsePrefix("fd7a:115c:a1e0::/48")
+
+	cfg := &types.Config{
+		ServerURL:           "http://localhost:0",
+		NoisePrivateKeyPath: tmpDir + "/noise_private.key",
+		PrefixV4:            &prefixV4,
+		PrefixV6:            &prefixV6,
+		IPAllocation:        types.IPAllocationStrategySequential,
+		Database: types.DatabaseConfig{
+			Type: "sqlite3",
+			Sqlite: types.SqliteConfig{
+				Path: tmpDir + "/headscale_test.db",
+			},
+		},
+		Policy: types.PolicyConfig{
+			Mode: types.PolicyModeDB,
+		},
+	}
+
+	h, err := NewHeadscale(cfg)
+	require.NoError(t, err)
+
+	reqBody, err := json.Marshal(tailcfg.DERPAdmitClientRequest{
+		NodePublic: key.NewNode().Public(),
+	})
+	require.NoError(t, err)
+
+	// A real HTTP server is required to observe the bug: the first body
+	// Write triggers an implicit WriteHeader that snapshots the header
+	// map, so a Content-Type set afterwards never reaches the wire.
+	// An httptest.ResponseRecorder does not snapshot, so it would hide
+	// the defect.
+	srv := httptest.NewServer(http.HandlerFunc(h.VerifyHandler))
+	defer srv.Close()
+
+	httpReq, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		srv.URL+"/verify",
+		bytes.NewReader(reqBody),
+	)
+	require.NoError(t, err)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"),
+		"successful /verify response must advertise application/json")
 }
 
 // errorAsHTTPError is a small local helper that unwraps an [HTTPError]

--- a/hscontrol/oidc.go
+++ b/hscontrol/oidc.go
@@ -54,6 +54,7 @@ var (
 		"authenticated principal does not match any allowed user",
 	)
 	errOIDCUnverifiedEmail = errors.New("authenticated principal has an unverified email")
+	errInvalidPKCEMethod   = errors.New("invalid pkce.method")
 )
 
 // AuthInfo contains both auth ID and verifier information for OIDC validation.
@@ -119,7 +120,8 @@ func (a *AuthProviderOIDC) AuthURL(authID types.AuthID) string {
 	return fmt.Sprintf(
 		"%s/auth/%s",
 		strings.TrimSuffix(a.serverURL, "/"),
-		authID.String())
+		authID.String(),
+	)
 }
 
 func (a *AuthProviderOIDC) AuthHandler(
@@ -133,7 +135,8 @@ func (a *AuthProviderOIDC) RegisterURL(authID types.AuthID) string {
 	return fmt.Sprintf(
 		"%s/register/%s",
 		strings.TrimSuffix(a.serverURL, "/"),
-		authID.String())
+		authID.String(),
+	)
 }
 
 // RegisterHandler registers the OIDC callback handler with the given router.
@@ -192,6 +195,12 @@ func (a *AuthProviderOIDC) authHandler(
 		case types.PKCEMethodPlain:
 			// oauth2 does not have a plain challenge option, so we add it manually
 			extras = append(extras, oauth2.SetAuthURLParam("code_challenge_method", "plain"), oauth2.SetAuthURLParam("code_challenge", verifier))
+		default:
+			// An unknown method must not silently emit no challenge: a
+			// verifier was generated and is sent at token exchange, so a
+			// missing challenge degrades to no-PKCE without anyone noticing.
+			httpError(writer, NewHTTPError(http.StatusInternalServerError, "internal server error", fmt.Errorf("%w: %q", errInvalidPKCEMethod, a.cfg.PKCE.Method)))
+			return
 		}
 	}
 

--- a/hscontrol/state/auth_nodekey_binding_test.go
+++ b/hscontrol/state/auth_nodekey_binding_test.go
@@ -1,0 +1,74 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/juanfont/headscale/hscontrol/db"
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/stretchr/testify/require"
+	"tailscale.com/tailcfg"
+)
+
+// TestPreAuthKeyReauthRejectsVictimNodeKey ensures the PAK re-registration
+// rotation path enforces the same 1:1 NodeKey<->MachineKey binding the other
+// registration paths do. NodeKeys are public (peers learn them from the
+// netmap), so an authenticated attacker must not be able to rotate their own
+// node's NodeKey onto a victim's NodeKey: doing so poisons the NodeStore
+// NodeKey index and denies the victim service.
+func TestPreAuthKeyReauthRejectsVictimNodeKey(t *testing.T) {
+	dbPath := t.TempDir() + "/headscale.db"
+	cfg := persistTestConfig(dbPath)
+
+	database, err := db.NewHeadscaleDatabase(cfg)
+	require.NoError(t, err)
+
+	// Attacker owns N_a under U_a with machine key M_a.
+	attacker := database.CreateUserForTest("attacker")
+	attackerNode := database.CreateRegisteredNodeForTest(attacker, "attacker-node")
+	attackerMachineKey := attackerNode.MachineKey
+
+	// Victim owns N_v under U_v with a distinct, public NodeKey K_v.
+	victim := database.CreateUserForTest("victim")
+	victimNode := database.CreateRegisteredNodeForTest(victim, "victim-node")
+	victimNodeKey := victimNode.NodeKey
+
+	require.NotEqual(t, attackerNode.NodeKey, victimNodeKey,
+		"precondition: attacker and victim must have distinct NodeKeys")
+	require.NotEqual(t, attackerNode.MachineKey, victimNode.MachineKey,
+		"precondition: attacker and victim must have distinct MachineKeys")
+
+	require.NoError(t, database.Close())
+
+	s, err := NewState(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Attacker mints their own valid pre-auth key for their own user.
+	attackerUserID := types.UserID(attacker.ID)
+	pak, err := s.CreatePreAuthKey(&attackerUserID, true, false, nil, nil)
+	require.NoError(t, err)
+
+	// Attacker re-registers over their own noise session (machine key M_a)
+	// with a valid PAK but carries the victim's NodeKey K_v and a non-past
+	// expiry (skipping the logout-first branch).
+	clientExpiry := time.Now().Add(180 * 24 * time.Hour)
+	regReq := tailcfg.RegisterRequest{
+		Auth:    &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey: victimNodeKey,
+		Expiry:  clientExpiry,
+		Hostinfo: &tailcfg.Hostinfo{
+			Hostname: "attacker-node",
+		},
+	}
+
+	_, _, err = s.HandleNodeFromPreAuthKey(regReq, attackerMachineKey)
+	require.ErrorIs(t, err, ErrNodeKeyInUse,
+		"attacker must not be able to claim the victim's NodeKey via PAK re-registration")
+
+	// The victim's NodeKey index must still resolve to the victim's node.
+	resolved, ok := s.nodeStore.GetNodeByNodeKey(victimNodeKey)
+	require.True(t, ok, "victim NodeKey must still be present in the index")
+	require.Equal(t, victimNode.MachineKey, resolved.MachineKey(),
+		"victim NodeKey must remain bound to the victim's MachineKey")
+}

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -558,7 +558,11 @@ func validateServerConfig() error {
 	// Removed: oidc.expiry -> node.expiry
 	depr.fatalIfSet("oidc.expiry", "node.expiry")
 
-	if viper.GetBool("oidc.enabled") {
+	// OIDC is activated by setting oidc.issuer (see app.go), not by a
+	// dedicated oidc.enabled key. Gate PKCE method validation on the real
+	// activation condition so an invalid method fails at startup instead of
+	// silently disabling PKCE at runtime.
+	if viper.GetString("oidc.issuer") != "" {
 		err := validatePKCEMethod(viper.GetString("oidc.pkce.method"))
 		if err != nil {
 			return err

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -1334,7 +1334,7 @@ func isSafeServerURL(serverURL, baseDomain string) error {
 		return errServerURLSame
 	}
 
-	serverDomainParts := strings.Split(server.Host, ".")
+	serverDomainParts := strings.Split(server.Hostname(), ".")
 	baseDomainParts := strings.Split(baseDomain, ".")
 
 	if len(serverDomainParts) <= len(baseDomainParts) {

--- a/hscontrol/types/config_test.go
+++ b/hscontrol/types/config_test.go
@@ -507,6 +507,47 @@ func TestSafeServerURL(t *testing.T) {
 	}
 }
 
+func TestSafeServerURLWithPort(t *testing.T) {
+	tests := []struct {
+		serverURL, baseDomain,
+		wantErr string
+	}{
+		{
+			serverURL:  "https://server.headscale.com:443",
+			baseDomain: "headscale.com",
+			wantErr:    errServerURLSuffix.Error(),
+		},
+		{
+			serverURL:  "https://server.subdomain.headscale.com:8080",
+			baseDomain: "headscale.com",
+			wantErr:    errServerURLSuffix.Error(),
+		},
+		{
+			serverURL:  "https://headscale.com:443",
+			baseDomain: "headscale.com",
+			wantErr:    errServerURLSame.Error(),
+		},
+		{
+			serverURL:  "https://example.com:8080",
+			baseDomain: "example.org",
+		},
+	}
+
+	for _, tt := range tests {
+		testName := fmt.Sprintf("server=%s domain=%s", tt.serverURL, tt.baseDomain)
+		t.Run(testName, func(t *testing.T) {
+			err := isSafeServerURL(tt.serverURL, tt.baseDomain)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
 // TestConfigJSONOmitsSecrets verifies that marshalling a [Config] to JSON
 // (as /debug/config does via [state.State.DebugConfig]) does not leak the
 // Postgres password, the OIDC client secret, or the headscale admin

--- a/hscontrol/types/config_test.go
+++ b/hscontrol/types/config_test.go
@@ -412,6 +412,38 @@ tls_letsencrypt_challenge_type: TLS-ALPN-01
 	require.NoError(t, err)
 }
 
+func TestPKCEMethodValidation(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// OIDC is active (issuer set) with PKCE enabled and an invalid method.
+	// There is no oidc.enabled key. validateServerConfig must reject the
+	// invalid method rather than silently skipping the check.
+	configYaml := []byte(`---
+noise:
+  private_key_path: noise_private.key
+server_url: http://127.0.0.1:8080
+dns:
+  override_local_dns: false
+oidc:
+  issuer: https://idp.example.com
+  client_id: headscale
+  pkce:
+    enabled: true
+    method: S256-typo
+`)
+
+	configFilePath := filepath.Join(tmpDir, "config.yaml")
+	err := os.WriteFile(configFilePath, configYaml, 0o600)
+	require.NoError(t, err)
+
+	err = LoadConfig(tmpDir, false)
+	require.NoError(t, err)
+
+	err = validateServerConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), errInvalidPKCEMethod.Error())
+}
+
 // OK
 // server_url: headscale.com, base: clients.headscale.com
 // server_url: headscale.com, base: headscale.net


### PR DESCRIPTION
Four correctness bugs surfaced by an audit of the control plane, each fixed test-first — a failing test that reproduces the defect, then the fix, then green. One commit per bug; every commit gated on `go build ./...` plus the touched package's tests.

**HIGH — `state`: NodeKey rotation onto a key already bound to another machine.** The pre-auth-key re-registration rotation branch in `HandleNodeFromPreAuthKey` wrote `node.NodeKey = regReq.NodeKey` with no 1:1 NodeKey/MachineKey guard, unlike its siblings `applyAuthNodeUpdate` and `createAndSaveNewNode` which both return `ErrNodeKeyInUse`. `regReq.NodeKey` is an attacker-controlled request field and NodeKey has no unique database index, so an authenticated attacker could re-register with a victim's public NodeKey, poison the NodeStore NodeKey index (last-write-wins over randomized map order), and 404 the victim's MapRequests — a cross-user denial of service. The guard is now applied in the rotation branch too, gated on `isNodeKeyRotation` so same-key re-registration is unaffected. Covered by `TestPreAuthKeyReauthRejectsVictimNodeKey`.

**MEDIUM — `types`: PKCE method validation gated on a key that is never set.** `validatePKCEMethod` ran only when `viper.GetBool("oidc.enabled")` was true, but `oidc.enabled` is a phantom key — OIDC actually activates on a non-empty `oidc.issuer`. An invalid `oidc.pkce.method` therefore passed startup validation and then matched neither arm of the runtime switch, emitting no `code_challenge` at all: PKCE silently off while the operator believed it enforced. Validation is now gated on `oidc.issuer`, and the auth-handler switch gained a `default` arm that errors on an unknown method instead of degrading to no challenge. Covered by `TestPKCEMethodValidation`.

**LOW — `handlers`: verify Content-Type set after the body was written.** `VerifyHandler` set `Content-Type: application/json` only after `handleVerifyRequest` had already written the response body, so the header was a no-op and successful `/verify` responses went out as sniffed `text/plain`. The header is now set before the write. Covered by `TestVerifyHandler_SuccessSetsJSONContentType`.

**LOW — `types`: server_url safety check compared against the host with its port.** `isSafeServerURL` split `server.Host` into domain labels, but `Host` retains the port, so a `server_url` carrying an explicit port that is a subdomain of `base_domain` slipped the suffix check and validation passed — fail-open. It now splits `server.Hostname()`, matching the port-less equality check above it. Covered by `TestSafeServerURLWithPort`.

A fifth audited item — the no-op `tailsqlContext.Done()` in graceful shutdown — was deliberately left out of this branch. It is dead, misleading code with no observable runtime behaviour (tailsql already tears down via `defer cancel()`), so it cannot be driven by a failing test. It belongs with the simplification cleanups, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
